### PR TITLE
Fix detection of 'repaired' pages

### DIFF
--- a/content.js
+++ b/content.js
@@ -507,7 +507,7 @@
           });
         }
 
-        if (pageText.includes("rapaired")) {
+        if (pageText.includes("repaired")) {
           foundRows = foundRows.map(row => {
             let pointsNum = parseFloat(row.points);
             if (!isNaN(pointsNum)) {


### PR DESCRIPTION
## Summary
- fix typo "rapaired" used in page text detection

## Testing
- `node --check content.js`

------
https://chatgpt.com/codex/tasks/task_e_684ec8b69e4c8333acf6224ca2fcb66a