### PR TITLE
Add optional iOS 26 CSS theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # punktuacja
 Punkuacija
 
+## iOS 26 style
+
+There is an optional stylesheet `ios26.css` that overrides the default color scheme
+to mimic the upcoming iOS&nbsp;26 look. Include it after the existing stylesheet
+links in your HTML to apply the theme.
+
 ## Running tests
 
 This project uses Node's built-in test runner. To execute the test suite run:

--- a/ios26.css
+++ b/ios26.css
@@ -1,0 +1,29 @@
+:root {
+  --radius: 12px;
+  --background-color: #f2f2f7;
+  --container-bg: rgba(255, 255, 255, 0.8);
+  --primary-color: #007aff;
+  --secondary-color: #3c3c43;
+  --text-color: #1c1c1e;
+  --border-color: #d1d1d6;
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Roboto", sans-serif;
+
+  --nav-bg: rgba(255, 255, 255, 0.8);
+  --nav-text: #1c1c1e;
+  --tab-active-bg: #007aff;
+
+  --button-bg: #007aff;
+  --button-text: #fff;
+  --button-hover-bg: #0051cc;
+
+  --input-bg: rgba(255, 255, 255, 0.9);
+  --input-border: #d1d1d6;
+  --input-text: #1c1c1e;
+}
+
+body {
+  background: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font-family);
+}

--- a/popup.html
+++ b/popup.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Punktuacja 0.5</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="ios26.css">
 </head>
 <body>
   <div class="popup-container liquid-glass">

--- a/settings.html
+++ b/settings.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Punctuation 0.2</title>
     <link rel="stylesheet" href="settings.css" />
+    <link rel="stylesheet" href="ios26.css" />
   </head>
   <body>
     <!-- Основное содержимое -->


### PR DESCRIPTION
## Summary
- introduce `ios26.css` with colors inspired by iOS 26
- link the new stylesheet in popup and settings pages
- document the theme in README

## Testing
- `npm test`
