### PR TITLE
Add glass edge blur

### DIFF
--- a/settings.css
+++ b/settings.css
@@ -68,6 +68,27 @@ body {
   transition: max-width 0.5s var(--ease-in-out-apple);
 }
 
+.container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 100%);
+}
+
+.container::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.2);
+}
+
 .container.calendar-active {
   max-width: 1600px;
 }
@@ -128,6 +149,8 @@ body {
 .mytable-container,
 .inventory-check-container,
 .calendar-container {
+  position: relative;
+  overflow: hidden;
   background: var(--container-bg);
   padding: 20px;
   border-radius: var(--radius);
@@ -135,6 +158,37 @@ body {
   backdrop-filter: blur(10px) saturate(140%);
   -webkit-backdrop-filter: blur(10px) saturate(140%);
   animation: fadeInScale 0.5s var(--ease-out-apple);
+}
+
+.settings-container::before,
+.inventory-container::before,
+.autoclicker-container::before,
+.mytable-container::before,
+.inventory-check-container::before,
+.calendar-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 100%);
+}
+
+.settings-container::after,
+.inventory-container::after,
+.autoclicker-container::after,
+.mytable-container::after,
+.inventory-check-container::after,
+.calendar-container::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.2);
 }
 
 @keyframes fadeInScale {
@@ -649,6 +703,8 @@ label:hover {
 }
 
 .edit-form {
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-wrap: nowrap;
   gap: 8px;
@@ -659,6 +715,27 @@ label:hover {
   backdrop-filter: blur(10px) saturate(140%);
   -webkit-backdrop-filter: blur(10px) saturate(140%);
   animation: formAppearWithBlur 0.4s ease-out forwards;
+}
+
+.edit-form::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 100%);
+}
+
+.edit-form::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.2);
 }
 
 .edit-form input,

--- a/style.css
+++ b/style.css
@@ -68,6 +68,8 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .liquid-glass {
+  position: relative;
+  overflow: hidden;
   background: linear-gradient(135deg, rgba(255,255,255,0.12) 0%, rgba(255,255,255,0.05) 50%, rgba(255,255,255,0.12) 100%);
   background-size: 200% 200%;
   animation: liquidGlassMove 8s ease infinite;
@@ -75,6 +77,27 @@ body::-webkit-scrollbar-thumb:hover {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 1px solid rgba(255,255,255,0.25);
   border-radius: var(--radius);
+}
+
+.liquid-glass::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 100%);
+}
+
+.liquid-glass::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.2);
 }
 
 .search-icon {
@@ -297,6 +320,7 @@ ul.label-list li {
 /* Стили для панели, создаваемой в content.js */
 .auto-found-panel {
   position: fixed;
+  overflow: hidden;
   bottom: 20px;
   right: 20px;
   width: 320px;
@@ -312,6 +336,27 @@ ul.label-list li {
   padding: 15px;
   color: var(--text-color);
   animation: slideUp 0.5s ease-out;
+}
+
+.auto-found-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  -webkit-mask: radial-gradient(circle, transparent 60%, #000 100%);
+          mask: radial-gradient(circle, transparent 60%, #000 100%);
+}
+
+.auto-found-panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.2);
 }
 
 @keyframes slideUp {


### PR DESCRIPTION
## Summary
- add radial blur on `.liquid-glass` edges to mimic refraction
- apply same blurred edges to auto-found panel
- extend refraction effect to settings containers and edit forms

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684edda3734c8333820904b979fba9cb