### PR TITLE
Improve button and calendar glow

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -168,5 +168,41 @@ document.querySelectorAll('.top-nav ul li').forEach(tab=>{
 prevMonthBtn.addEventListener('click',()=>{ currentDate.setMonth(currentDate.getMonth()-1); debouncedGenerateCalendar(); });
 nextMonthBtn.addEventListener('click',()=>{ currentDate.setMonth(currentDate.getMonth()+1); debouncedGenerateCalendar(); });
 
+/* ==== Proximity glow on elements ==== */
+function applyProximityGlow(container, selector, range = 150) {
+  let frame;
+
+  function update(x, y) {
+    container.querySelectorAll(selector).forEach(el => {
+      if (el.classList && el.classList.contains('empty')) {
+        el.style.removeProperty('--glow');
+        return;
+      }
+      const r = el.getBoundingClientRect();
+      const dx = Math.max(r.left - x, 0, x - r.right);
+      const dy = Math.max(r.top - y, 0, y - r.bottom);
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const intensity = Math.max(0, 1 - dist / range);
+      el.style.setProperty('--glow', intensity.toFixed(2));
+    });
+  }
+
+  function handleMove(e) {
+    const { clientX, clientY } = e;
+    if (frame) cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => update(clientX, clientY));
+  }
+
+  function clear() {
+    container.querySelectorAll(selector).forEach(el => el.style.removeProperty('--glow'));
+  }
+
+  container.addEventListener('mousemove', handleMove);
+  container.addEventListener('mouseleave', clear);
+}
+
+applyProximityGlow(calendarGrid, '.day-card');
+applyProximityGlow(document.body, '.macos-btn', 120);
+
 /* ==== Initial draw ==== */
 generateCalendar();

--- a/settings.css
+++ b/settings.css
@@ -245,36 +245,50 @@ input[type="checkbox"]:checked::after {
 }
 
 .macos-btn {
-  padding: 8px 16px;
-  border: none;
-  border-radius: var(--radius);
-  background: var(--button-bg);
-  color: var(--button-text);
+  --glow: 0;
+  position: relative;
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--button-bg);
+  background: transparent;
+  color: var(--button-bg);
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.3s ease, opacity 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 2px 4px var(--shadow-color);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: none;
   margin-bottom: 10px;
 }
 
+.macos-btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 2px solid rgba(10, 132, 255, var(--glow));
+  box-shadow: 0 0 8px rgba(10, 132, 255, var(--glow));
+  opacity: var(--glow);
+  transition: opacity 0.1s ease, box-shadow 0.1s ease, border-color 0.1s ease;
+}
+
 .macos-btn:hover {
-  background: var(--button-hover-bg);
-  opacity: 0.9;
-  box-shadow: 0 3px 6px var(--shadow-color);
+  background: var(--button-bg);
+  color: var(--button-text);
+  box-shadow: 0 0 6px rgba(10, 132, 255, 0.4);
 }
 
 .macos-btn:active {
-  opacity: 0.7;
-  transition: opacity 0.1s ease;
+  transform: translateY(1px);
 }
 
 .macos-btn.secondary {
-  background: #5a5a5a;
+  border-color: #5a5a5a;
+  color: #5a5a5a;
 }
 
 .macos-btn.secondary:hover {
-  background: #7f7f7f;
-  opacity: 0.9;
+  background: #5a5a5a;
+  color: #fff;
 }
 
 label {
@@ -542,17 +556,19 @@ label:hover {
 }
 
 .macos-btn.small-gray {
-  background: #5a5a5a;
+  background: transparent;
+  border: 1px solid #5a5a5a;
+  color: #5a5a5a;
   font-size: 0.8rem;
-  padding: 5px 10px;
+  padding: 4px 8px;
   margin-bottom: 10px;
-  transition: background 0.3s ease, opacity 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .macos-btn.small-gray:hover {
-  background: #7f7f7f;
-  opacity: 0.9;
-  box-shadow: 0 3px 6px var(--shadow-color);
+  background: #5a5a5a;
+  color: #fff;
+  box-shadow: 0 0 4px rgba(255, 255, 255, 0.4);
 }
 
 #inventory-table-container.collapsed {
@@ -754,6 +770,7 @@ label:hover {
 }
 
 .day-card {
+  --glow: 0;
   background: rgba(28, 28, 30, 0.9);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -763,6 +780,18 @@ label:hover {
   position: relative;
   animation: cardAppear 0.3s ease-out;
   min-height: 120px;
+}
+
+.day-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  border: 2px solid rgba(10, 132, 255, var(--glow));
+  box-shadow: 0 0 8px rgba(10, 132, 255, var(--glow));
+  opacity: var(--glow);
+  transition: opacity 0.1s ease, box-shadow 0.1s ease, border-color 0.1s ease;
 }
 
 .day-card.empty {


### PR DESCRIPTION
## Summary
- refine macOS button styling with proximity glow
- update day-card border glow styling
- implement proximity glow logic for buttons and cards in JS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684edd605fb083339b6a5afa437f4b25