### PR TITLE
Add animated line chart for calendar stats

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -24,6 +24,8 @@ const container          = document.querySelector('.container');
 const growthPointsEl     = document.getElementById('growth-points');
 const growthOkEl         = document.getElementById('growth-ok');
 const growthBerEl        = document.getElementById('growth-ber');
+const lineChartCanvas    = document.getElementById('calendar-line-chart');
+let lineChart;
 
 const dayTooltip = document.createElement('div');
 dayTooltip.className = 'day-tooltip';
@@ -105,6 +107,8 @@ function updateSummary(year,month){
   if(growthPointsEl) growthPointsEl.textContent=g.pointsDiff.toFixed(2);
   if(growthOkEl) growthOkEl.textContent=g.totalOK.toFixed(2);
   if(growthBerEl) growthBerEl.textContent=g.totalBER.toFixed(2);
+
+  updateLineChart(year, month);
 }
 
 /* ==== Calendar render (original logic + map save) ==== */
@@ -214,6 +218,41 @@ function calculateGrowthStats(year, month){
     ber+=+data.ber||0;
   }
   return {pointsDiff:diff,totalOK:ok,totalBER:ber};
+}
+
+function updateLineChart(year, month){
+  if(!lineChartCanvas) return;
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const labels = [];
+  const berData = [];
+  const okData = [];
+  const pointsData = [];
+  for(let d=1; d<=daysInMonth; d++){
+    const key = formatDate(new Date(year, month, d));
+    const data = calendarData[key] || {points:0, ok:0, ber:0};
+    labels.push(String(d));
+    berData.push(+data.ber || 0);
+    okData.push(+data.ok || 0);
+    pointsData.push(+data.points || 0);
+  }
+  if(lineChart) lineChart.destroy();
+  lineChart = new Chart(lineChartCanvas, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'BER', data: berData, borderColor: '#ff3b30', tension: 0.2, fill: false },
+        { label: 'OK', data: okData, borderColor: '#34c759', tension: 0.2, fill: false },
+        { label: 'Points', data: pointsData, borderColor: '#0a84ff', tension: 0.2, fill: false }
+      ]
+    },
+    options: {
+      responsive: true,
+      animation: { duration: 700 },
+      scales: { y: { beginAtZero: true } },
+      plugins: { legend: { labels: { color: '#F5F5F7' } } }
+    }
+  });
 }
 
 function handleMouseMove(e) {

--- a/settings.css
+++ b/settings.css
@@ -630,6 +630,16 @@ label:hover {
   transition: max-width 0.5s var(--ease-in-out-apple);
 }
 
+.line-chart-container {
+  width: 100%;
+  margin-top: 20px;
+}
+
+#calendar-line-chart {
+  width: 100%;
+  max-height: 300px;
+}
+
 .day-block {
   margin-bottom: 20px;
   background: rgba(44, 44, 46, 0.3);
@@ -923,12 +933,13 @@ label:hover {
   border-radius: 10px;
   overflow: hidden;
   margin: 10px 0;
+  box-shadow: inset 0 0 4px rgba(0,0,0,0.6);
 }
 
 .progress-bar-fill {
   height: 100%;
-  background: var(--primary-color);
-  transition: width 0.3s ease;
+  background: linear-gradient(90deg, #0A84FF, #2BD154);
+  transition: width 0.4s ease;
 }
 
 .calendar-container.wide-panel {
@@ -1044,4 +1055,6 @@ label:hover {
     max-width: 100%;
     padding: 10px;
   }
+
 }
+

--- a/settings.html
+++ b/settings.html
@@ -247,6 +247,10 @@
       <span><strong>Total Points:</strong> <span id="total-points">0</span></span>
       <span><strong>Yield:</strong> <span id="calendar-yield">0</span>%</span>
     </div>
+
+    <div class="line-chart-container">
+      <canvas id="calendar-line-chart"></canvas>
+    </div>
   </div>
 </section>
 
@@ -288,6 +292,7 @@
     <script src="popup.js"></script>
     <script src="autoclicker_tasks.js"></script>
     <script src="yieldtable.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="calendar.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize the progress bar styling
- add a canvas for an animated line chart in the calendar panel
- load Chart.js via CDN
- render BER/OK/Points data on the new chart